### PR TITLE
feat: 회원가입 페이지 UI 및 입력 검증 기능 구현 (#3)

### DIFF
--- a/src/pages/SignUpPage.jsx
+++ b/src/pages/SignUpPage.jsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import {
+  Box, Input, Button, Text, VStack, InputGroup,
+  InputRightElement, IconButton, Flex, Divider
+} from "@chakra-ui/react";
+import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
+import { useNavigate } from "react-router-dom";
+
+function SignUpPage() {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    username: "",
+    name: "",
+    birthdate: "",
+    password: "",
+    confirmPassword: ""
+  });
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSignUp = (e) => {
+    e.preventDefault(); //  form 기본 동작 방지
+    setError("");
+
+    if (!formData.username || !formData.name || !formData.birthdate || !formData.password || !formData.confirmPassword) {
+      setError("모든 필드를 입력하세요.");
+      return;
+    }
+    if (formData.password !== formData.confirmPassword) {
+      setError("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    alert("회원가입 성공!");
+    navigate("/login"); // 회원가입 완료 후 로그인 화면으로 이동
+  };
+
+  return (
+    <Flex align="center" justify="center" h="100vh" bg="gray.50">
+      <Box w="400px" bg="white" p={8} boxShadow="md" borderRadius="lg">
+        {/* form 태그로 감싸기 */}
+        <form onSubmit={handleSignUp}>
+          <VStack spacing={4} align="stretch">
+            <Text fontSize="xl" fontWeight="bold" textAlign="center">회원가입</Text>
+
+            <Text fontSize="sm">아이디</Text>
+            <Input
+              placeholder="아이디 입력"
+              name="username"
+              value={formData.username}
+              onChange={handleChange}
+            />
+
+            <Text fontSize="sm">이름</Text>
+            <Input
+              placeholder="이름 입력"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+            />
+
+            <Text fontSize="sm">생년월일</Text>
+            <Input
+              placeholder="YYYY-MM-DD"
+              type="date"
+              name="birthdate"
+              value={formData.birthdate}
+              onChange={handleChange}
+            />
+
+            <Text fontSize="sm">비밀번호</Text>
+            <InputGroup>
+              <Input
+                placeholder="비밀번호 입력"
+                type={showPassword ? "text" : "password"}
+                name="password"
+                value={formData.password}
+                onChange={handleChange}
+              />
+              <InputRightElement>
+                <IconButton
+                  icon={showPassword ? <ViewOffIcon /> : <ViewIcon />}
+                  onClick={() => setShowPassword(!showPassword)}
+                  variant="ghost"
+                  aria-label="비밀번호 보기"
+                />
+              </InputRightElement>
+            </InputGroup>
+
+            <Text fontSize="sm">비밀번호 확인</Text>
+            <InputGroup>
+              <Input
+                placeholder="비밀번호 확인"
+                type={showConfirmPassword ? "text" : "password"}
+                name="confirmPassword"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+              />
+              <InputRightElement>
+                <IconButton
+                  icon={showConfirmPassword ? <ViewOffIcon /> : <ViewIcon />}
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  variant="ghost"
+                  aria-label="비밀번호 확인 보기"
+                />
+              </InputRightElement>
+            </InputGroup>
+
+            {error && <Text color="red.500" fontSize="sm">{error}</Text>}
+
+            <Button type="submit" colorScheme="blue" w="full">
+              회원가입
+            </Button>
+
+            <Divider />
+
+            <Button variant="link" colorScheme="blue" onClick={() => navigate("/login")}>
+              로그인 화면으로 이동
+            </Button>
+          </VStack>
+        </form>
+      </Box>
+    </Flex>
+  );
+}
+
+export default SignUpPage;


### PR DESCRIPTION
## 연관된 작업사항
- #3

## 작업내용

- Chakra UI 기반 회원가입 카드형 폼 UI 구성
- 입력 필드: 아이디, 이름, 생년월일, 비밀번호, 비밀번호 확인
- 모든 입력값 필수 유효성 검사 처리
- 비밀번호 / 비밀번호 확인 일치 여부 검사
- 아이디 유효성 검사 추가 (영문+숫자 조합, 길이 제한)
- 아이디 중복 검사 로직 추가 (가상 리스트 기반, 서버 미연동)
- 생년월일 형식 유효성 검사 및 만 14세 미만 가입 제한 처리
- 비밀번호 보안 검사 추가 (8자 이상, 영문+숫자 포함, 아이디 동일 금지)
- form 태그 기반 제출 구조 적용 (onSubmit + preventDefault)
- 회원가입 성공 시 알림 및 `/login` 경로로 이동 처리
- 로그인 페이지 이동 버튼 추가

> 현재는 백엔드와 연동되지 않은 상태로, 입력 유효성 검사 및 기본 UI 흐름만 구현되어 있습니다.  
> 이후 서버 구현 시 `axios.post("/api/signup", formData)` 방식으로 API 연동 예정입니다.


## 리뷰 체크리스트 (회원가입 기능)
혹시 몰라서 체크리스트도 같이 첨부하였습니다. 필요 시에 참고하시면 됩니다!

<details>
<summary>클릭해서 확인</summary>

###  UI 구성
- [ ] 모든 필드가 카드형 UI로 구성되어 있는가?
- [ ] Chakra UI 컴포넌트가 일관되게 사용되었는가?

###  유효성 검사
- [ ] 모든 입력값에 대해 필수 입력 검사가 적용되어 있는가?
- [ ] 비밀번호/비밀번호 확인 일치 여부가 검사되는가?
- [ ] 에러 메시지가 명확하게 출력되는가?

###  폼 구조 및 제출 처리
- [ ] form 태그 기반 구조로 되어 있으며 `onSubmit`을 사용하고 있는가?
- [ ] Enter 키 입력 시에도 회원가입이 동작하는가?

###  흐름 전환
- [ ] 회원가입 성공 시 로그인 페이지(`/login`)로 이동되는가?
- [ ] 로그인 페이지 이동 버튼이 동작하는가?

</details>

## Reference

## etc.
