### PR TITLE
로컬스토리지 제거 및 로그인 상태 메모리 기반으로 변경

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { createContext, useContext, useState, useEffect } from "react";
+import React, { createContext, useContext, useState } from "react";
 
 const AuthContext = createContext();
 
@@ -7,25 +6,16 @@ export function AuthProvider({ children }) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [username, setUsername] = useState("");
 
-  // 앱 시작할 때 localStorage에서 로그인 정보 복원
-  useEffect(() => {
-    const savedUsername = localStorage.getItem("username");
-    if (savedUsername) {
-      setIsLoggedIn(true);
-      setUsername(savedUsername);
-    }
-  }, []);
-
   const login = (name) => {
     setIsLoggedIn(true);
     setUsername(name);
-    localStorage.setItem("username", name); // 로그인 성공 시 저장
+    // localStorage.setItem("username", name); → 제거됨
   };
 
   const logout = () => {
     setIsLoggedIn(false);
     setUsername("");
-    localStorage.removeItem("username"); // 로그아웃 시 삭제
+    // localStorage.removeItem("username"); → 제거됨
   };
 
   return (

--- a/src/pages/PreferenceSurvey.jsx
+++ b/src/pages/PreferenceSurvey.jsx
@@ -1,196 +1,179 @@
-import React from "react";
+import React, { useState } from "react";
 import {
-    Box,
-    Heading,
-    Text,
-    Button,
-    Wrap,
-    WrapItem,
-    RadioGroup,
-    Radio,
-    Stack,
-    Slider,
-    SliderTrack,
-    SliderFilledTrack,
-    SliderThumb,
-    Alert,
-    AlertIcon,
-    Tag,
-    TagLabel,
-    Spinner,
-  } from "@chakra-ui/react";
-  import { useState } from "react";
-  import { useNavigate } from "react-router-dom";
-  import axios from "axios";
-  
-  function PreferenceSurvey() {
-    const [formData, setFormData] = useState({
-      type: "",
-      activity: "",
-      transport: "",
-      intensity: 1 // 기본값 1로 변경,
+  Box,
+  Heading,
+  Text,
+  Button,
+  Wrap,
+  WrapItem,
+  RadioGroup,
+  Radio,
+  Stack,
+  Slider,
+  SliderTrack,
+  SliderFilledTrack,
+  SliderThumb,
+  Spinner,
+} from "@chakra-ui/react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+
+function PreferenceSurvey() {
+  const [formData, setFormData] = useState({
+    type: "",
+    activity: "",
+    transport: "",
+    intensity: 1,
+    interests: [], // 누락되어 있던 interests 초기화
+  });
+
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleInterestToggle = (item) => {
+    setFormData((prev) => {
+      const exists = prev.interests.includes(item);
+      return {
+        ...prev,
+        interests: exists
+          ? prev.interests.filter((i) => i !== item)
+          : [...prev.interests, item],
+      };
     });
-  
-    const [error, setError] = useState("");
-    const [loading, setLoading] = useState(false);
-    const navigate = useNavigate();
-  
-    const handleInterestToggle = (item) => {
-      setFormData((prev) => {
-        const exists = prev.interests.includes(item);
-        return {
-          ...prev,
-          interests: exists
-            ? prev.interests.filter((i) => i !== item)
-            : [...prev.interests, item],
-        };
+  };
+
+  const isValid =
+    formData.type &&
+    formData.activity &&
+    formData.transport &&
+    formData.intensity > 0;
+
+  const handleSubmit = async () => {
+    try {
+      setLoading(true);
+
+      await axios.post("/api/survey-detail", formData, {
+        headers: {
+          "Content-Type": "application/json",
+        },
       });
-    };
-  
-    const isValid =
-      formData.type &&
-      formData.activity &&
-      formData.transport &&
-      formData.intensity > 0;
-  
-    const handleSubmit = async () => {
-      try {
-        setLoading(true);
-        setError("");
-  
-        await axios.post("/api/survey-detail", formData, {
-          headers: {
-            "Content-Type": "application/json",
-          },
-        });
-  
-        navigate("/final-recommendation");
-      } catch (err) {
-        const message =
-          err?.response?.data?.message || "설문 저장에 실패했습니다.";
-        setError(message);
-      } finally {
-        setLoading(false);
-      }
-    };
-  
-    return (
-      <Box bgGradient="linear(to-b, blue.50, white)" minH="100vh" py={10}>
-        <Box
-          maxW="800px"
-          mx="auto"
-          p={8}
-          bg="white"
-          borderRadius="2xl"
-          boxShadow="2xl"
-        >
-          <Heading size="lg" mb={6} textAlign="center">
-            ✨ 여행 취향 상세 설문
-          </Heading>
-  
-          {/* 1. 여행 유형 */}
-          <Box mb={6}>
-            <Text fontSize="sm" color="gray.500">Q1</Text>
-            <Text fontSize="lg" fontWeight="bold" mb={3}>선호하는 여행 유형</Text>
-            <Wrap>
-              {["실내", "야외"].map((item) => (
-                <WrapItem key={item}>
-                  <Button
-                    variant={formData.type === item ? "solid" : "outline"}
-                    colorScheme="blue"
-                    onClick={() => setFormData({ ...formData, type: item })}
-                  >
-                    {item}
-                  </Button>
-                </WrapItem>
-              ))}
-            </Wrap>
-          </Box>
-  
-          {/* 2. 활동 선택 */}
-          <Box mb={6}>
-            <Text fontSize="sm" color="gray.500">Q2</Text>
-            <Text fontSize="lg" fontWeight="bold" mb={3}>활동 선택</Text>
-            <Wrap>
-              {(formData.type === "실내"
-                ? ["맛집 탐방", "카페 투어", "전시 관람", "스파", "쇼핑"]
-                : ["등산", "해변 산책", "액티비티", "유적지 탐방", "테마파크"]
-              ).map((item) => (
-                <WrapItem key={item}>
-                  <Button
-                    variant={formData.activity === item ? "solid" : "outline"}
-                    colorScheme="green"
-                    onClick={() => setFormData({ ...formData, activity: item })}
-                  >
-                    {item}
-                  </Button>
-                </WrapItem>
-              ))}
-            </Wrap>
-          </Box>
-  
-          {/* 3. 이동수단 */}
-          <Box mb={6}>
-            <Text fontSize="sm" color="gray.500">Q3</Text>
-            <Text fontSize="lg" fontWeight="bold" mb={3}>선호하는 이동수단</Text>
-            <RadioGroup
-              value={formData.transport}
-              onChange={(val) => setFormData({ ...formData, transport: val })}
-            >
-              <Stack direction="row" spacing={5}>
-                <Radio value="자동차">자동차</Radio>
-                <Radio value="기차">기차</Radio>
-                <Radio value="버스">버스</Radio>
-              </Stack>
-            </RadioGroup>
-          </Box>
-  
-          {/* 4. 활동량 */}
-          <Box mb={6}>
-            <Text fontSize="sm" color="gray.500">Q4</Text>
-            <Text fontSize="lg" fontWeight="bold" mb={3}>활동량 (1~10)</Text>
-            <Slider
-              defaultValue={formData.intensity}
-              min={1}
-              max={10}
-              step={1}
-              onChange={(val) => setFormData({ ...formData, intensity: val })}
-            >
-              <SliderTrack><SliderFilledTrack /></SliderTrack>
-              <SliderThumb boxSize={6} />
-            </Slider>
-            <Text mt={1} textAlign="right" fontSize="sm" color="gray.600">
-              {formData.intensity} / 10
-            </Text>
-          </Box>
-  
 
+      navigate("/final-recommendation");
+    } catch (err) {
+      console.warn("서버 없음 - 다음 페이지로 강제 이동");
 
-  
-          {/* 에러 메시지 */}
-          {error && (
-            <Alert status="error" mt={4} borderRadius="md">
-              <AlertIcon />
-              {error}
-            </Alert>
-          )}
-  
-          {/* 제출 버튼 */}
-          <Box mt={10} textAlign="center">
-            <Button
-              colorScheme="blue"
-              size="lg"
-              onClick={handleSubmit}
-              isDisabled={!isValid || loading}
-            >
-              {loading ? <Spinner size="sm" mr={2} /> : null}
-              제출하기
-            </Button>
-          </Box>
+      // 백엔드 없으므로 에러 무시하고 이동
+      navigate("/final-recommendation");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box bgGradient="linear(to-b, blue.50, white)" minH="100vh" py={10}>
+      <Box
+        maxW="800px"
+        mx="auto"
+        p={8}
+        bg="white"
+        borderRadius="2xl"
+        boxShadow="2xl"
+      >
+        <Heading size="lg" mb={6} textAlign="center">
+          ✨ 여행 취향 상세 설문
+        </Heading>
+
+        {/* 1. 여행 유형 */}
+        <Box mb={6}>
+          <Text fontSize="sm" color="gray.500">Q1</Text>
+          <Text fontSize="lg" fontWeight="bold" mb={3}>선호하는 여행 유형</Text>
+          <Wrap>
+            {["실내", "야외"].map((item) => (
+              <WrapItem key={item}>
+                <Button
+                  variant={formData.type === item ? "solid" : "outline"}
+                  colorScheme="blue"
+                  onClick={() => setFormData({ ...formData, type: item })}
+                >
+                  {item}
+                </Button>
+              </WrapItem>
+            ))}
+          </Wrap>
+        </Box>
+
+        {/* 2. 활동 선택 */}
+        <Box mb={6}>
+          <Text fontSize="sm" color="gray.500">Q2</Text>
+          <Text fontSize="lg" fontWeight="bold" mb={3}>활동 선택</Text>
+          <Wrap>
+            {(formData.type === "실내"
+              ? ["맛집 탐방", "카페 투어", "전시 관람", "스파", "쇼핑"]
+              : ["등산", "해변 산책", "액티비티", "유적지 탐방", "테마파크"]
+            ).map((item) => (
+              <WrapItem key={item}>
+                <Button
+                  variant={formData.activity === item ? "solid" : "outline"}
+                  colorScheme="green"
+                  onClick={() => setFormData({ ...formData, activity: item })}
+                >
+                  {item}
+                </Button>
+              </WrapItem>
+            ))}
+          </Wrap>
+        </Box>
+
+        {/* 3. 이동수단 */}
+        <Box mb={6}>
+          <Text fontSize="sm" color="gray.500">Q3</Text>
+          <Text fontSize="lg" fontWeight="bold" mb={3}>선호하는 이동수단</Text>
+          <RadioGroup
+            value={formData.transport}
+            onChange={(val) => setFormData({ ...formData, transport: val })}
+          >
+            <Stack direction="row" spacing={5}>
+              <Radio value="자동차">자동차</Radio>
+              <Radio value="기차">기차</Radio>
+              <Radio value="버스">버스</Radio>
+            </Stack>
+          </RadioGroup>
+        </Box>
+
+        {/* 4. 활동량 */}
+        <Box mb={6}>
+          <Text fontSize="sm" color="gray.500">Q4</Text>
+          <Text fontSize="lg" fontWeight="bold" mb={3}>활동량 (1~10)</Text>
+          <Slider
+            defaultValue={formData.intensity}
+            min={1}
+            max={10}
+            step={1}
+            onChange={(val) => setFormData({ ...formData, intensity: val })}
+          >
+            <SliderTrack><SliderFilledTrack /></SliderTrack>
+            <SliderThumb boxSize={6} />
+          </Slider>
+          <Text mt={1} textAlign="right" fontSize="sm" color="gray.600">
+            {formData.intensity} / 10
+          </Text>
+        </Box>
+
+        {/* 제출 버튼 */}
+        <Box mt={10} textAlign="center">
+          <Button
+            colorScheme="blue"
+            size="lg"
+            onClick={handleSubmit}
+            isDisabled={!isValid || loading}
+          >
+            {loading ? <Spinner size="sm" mr={2} /> : null}
+            제출하기
+          </Button>
         </Box>
       </Box>
-    );
-  }
-  
-  export default PreferenceSurvey;
-  
+    </Box>
+  );
+}
+
+export default PreferenceSurvey;


### PR DESCRIPTION
###  변경 사항
- 기존 localStorage를 통한 로그인 상태 저장 제거
- 로그인/로그아웃 시 메모리 기반 상태만 사용
- 새로고침 시 로그인 상태 유지되지 않도록 변경

### 테스트
- 로그인 → 상태 유지 확인 (페이지 내 이동 시)
- 새로고침 시 로그인 초기화됨

관련 이슈: #43

### 추가 수정
- PreferenceSurvey 페이지에서 백엔드 연동 실패 시에도 다음 페이지(/final-recommendation)로 이동하도록 fallback 처리

