### PR TITLE
[REFACTOR] PlanDetailPage 리팩토링 및 ScheduleCard 분리, 지도 안내 UI 적용 (#34)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,9 @@ import HotDestinationDetail from "./pages/HotDestinationDetail";
 import PlanRecommendationPage from "./pages/PlanRecommendationPage";
 import FinalRecommendationPage from "./pages/FinalRecommendationPage";
 
+import PlanDetailPage from "./pages/PlanDetailPage"; 
+
+
 import { TravelProvider } from "./contexts/TravelContext";
 import { AuthProvider } from "./contexts/AuthContext";
 
@@ -89,6 +92,8 @@ function App() {
               }
               />
 
+
+
     
             </Route>
 
@@ -120,6 +125,17 @@ function App() {
                   </PrivateRoute>
                 }
               />
+
+              
+<Route
+  path="/plan/:region"
+  element={
+    <PrivateRoute>
+      <PlanDetailPage />
+    </PrivateRoute>
+  }
+/>
+
           </Routes>
         </TravelProvider>
       </AuthProvider>

--- a/src/components/ScheduleCard.jsx
+++ b/src/components/ScheduleCard.jsx
@@ -1,0 +1,26 @@
+// src/components/ScheduleCard.jsx
+import React from "react";
+import { Box, Button, HStack, Text } from "@chakra-ui/react";
+import { StarIcon } from "@chakra-ui/icons";
+
+const ScheduleCard = ({ item, onDelete, onReview }) => {
+  return (
+    <Box p={4} borderWidth="1px" borderRadius="md">
+      <HStack justify="space-between">
+        <Text fontWeight="bold">{item.title}</Text>
+        <Button variant="ghost" onClick={onReview}>
+          <StarIcon boxSize="20px" color="gray.500" /> 리뷰
+        </Button>
+      </HStack>
+      <Text>{item.desc}</Text>
+      <Text mt={1} fontSize="sm" color="gray.600">
+        ⏰ {item.time} / 🚗 {item.transport}
+      </Text>
+      <Button size="xs" colorScheme="red" mt={2} onClick={onDelete}>
+        삭제
+      </Button>
+    </Box>
+  );
+};
+
+export default ScheduleCard;

--- a/src/pages/PlanDetailPage.jsx
+++ b/src/pages/PlanDetailPage.jsx
@@ -1,0 +1,158 @@
+// src/pages/PlanDetailPage.jsx
+import React, { useState } from "react";
+import { useParams } from "react-router-dom";
+import {
+  Box,
+  Heading,
+  Text,
+  Button,
+  HStack,
+  VStack,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  useDisclosure,
+} from "@chakra-ui/react";
+import Header from "../components/Header";
+// import InviteModal from "../components/InviteModal";
+// import ReviewModal from "../components/ReviewModal";
+// import AddScheduleModal from "../components/admin/AddScheduleModal";
+import ScheduleCard from "../components/ScheduleCard";
+
+const PlanDetailPage = () => {
+  const { region } = useParams();
+
+  const {
+    isOpen: isInviteOpen,
+    onOpen: onInviteOpen,
+    onClose: onInviteClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: isReviewOpen,
+    onOpen: onReviewOpen,
+    onClose: onReviewClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: isAddOpen,
+    onOpen: onAddOpen,
+    onClose: onAddClose,
+  } = useDisclosure();
+
+  const regionNameMap = {
+    namhae: "남해",
+    jindo: "진도",
+    jeju: "제주도",
+    sokcho: "속초",
+    busan: "부산",
+  };
+  const regionName = regionNameMap[region] || region;
+
+  const tripDays = ["1일차", "2일차", "3일차"];
+
+  const [schedule, setSchedule] = useState([
+    {
+      day: "1일차",
+      title: "남해항",
+      desc: "아름다운 항구 전망과 해산물",
+      time: "10:00",
+      transport: "자동차",
+    },
+    {
+      day: "1일차",
+      title: "독일마을",
+      desc: "이국적인 분위기의 건축물과 카페",
+      time: "14:00",
+      transport: "도보",
+    },
+  ]);
+
+  const handleAddSchedule = (newItem) => {
+    setSchedule([...schedule, newItem]);
+  };
+
+  const handleDeleteSchedule = (targetItem) => {
+    setSchedule(schedule.filter((item) => item !== targetItem));
+  };
+
+  const handleOptimizeRoute = () => {
+    alert("최적 경로를 계산 중입니다... (추후 API 연동 예정)");
+  };
+
+  return (
+    <>
+      <Header />
+      <Box bgGradient="linear(to-b, blue.200, white)" py={10} textAlign="center" />
+      <Box bg="gray.50" minH="100vh" p={6}>
+        <HStack align="start" spacing={6}>
+          <Box w="220px" bg="blue.100" p={4} borderRadius="md" boxShadow="md">
+            <Heading size="md" mb={4}>일정 관리</Heading>
+            <VStack align="stretch" spacing={2}>
+              <Button variant="solid" colorScheme="blue">남해 여행</Button>
+              <Button variant="solid" colorScheme="blue">진도 여행</Button>
+              <Button variant="solid" colorScheme="blue">제주도 여행</Button>
+            </VStack>
+          </Box>
+
+          <Box flex="1">
+            <Heading mb={4}>{regionName?.toUpperCase()} 여행 일정</Heading>
+            <Text mb={6}>최적의 경로와 시간을 구성해보세요.</Text>
+
+            {/* 지도 영역 안내 박스 */}
+            <Box flex="1" bg="gray.100" p={6} mb={4}>
+              <Box bg="white" p={6} borderRadius="md" boxShadow="md" textAlign="center">
+                <Text fontSize="lg" fontWeight="semibold">📍 추후 지도 연동 예정</Text>
+                <Text color="gray.600" mt={2}>Google Maps 또는 Kakao Maps 연동 가능합니다.</Text>
+              </Box>
+            </Box>
+
+            <HStack justify="flex-end" mb={4} spacing={2}>
+              <Button colorScheme="green" onClick={handleOptimizeRoute}>
+                🚗 최적 동선 보기
+              </Button>
+              <Button colorScheme="blue" onClick={onAddOpen}>일정 추가 / 삭제</Button>
+              <Button variant="outline" colorScheme="blue" onClick={onInviteOpen}>일정 공유</Button>
+            </HStack>
+
+            <Tabs variant="enclosed" colorScheme="blue">
+              <TabList>
+                {tripDays.map((day) => (
+                  <Tab key={day}>{day}</Tab>
+                ))}
+              </TabList>
+              <TabPanels>
+                {tripDays.map((day) => (
+                  <TabPanel key={day}>
+                    <VStack align="stretch" spacing={4}>
+                      {schedule.filter((item) => item.day === day).map((item, idx) => (
+                        <ScheduleCard
+                          key={idx}
+                          item={item}
+                          onDelete={() => handleDeleteSchedule(item)}
+                          onReview={onReviewOpen}
+                        />
+                      ))}
+                      {schedule.filter((item) => item.day === day).length === 0 && (
+                        <Text>{day} 일정은 준비 중입니다.</Text>
+                      )}
+                    </VStack>
+                  </TabPanel>
+                ))}
+              </TabPanels>
+            </Tabs>
+          </Box>
+        </HStack>
+
+        {/* 향후 모달 복원 예정 */}
+        {/* <InviteModal isOpen={isInviteOpen} onClose={onInviteClose} regionName={regionName} startDate="2025.3.15" endDate="2025.3.18" />
+        <ReviewModal isOpen={isReviewOpen} onClose={onReviewClose} />
+        <AddScheduleModal isOpen={isAddOpen} onClose={onAddClose} onAdd={handleAddSchedule} /> */}
+      </Box>
+    </>
+  );
+};
+
+export default PlanDetailPage;


### PR DESCRIPTION
## PlanDetailPage 리팩토링 및 일정 카드 분리, 지도 안내 UI 적용

### 주요 변경 사항
- `PlanDetailPage.jsx` 리팩토링:
  - 일정 관리 Tabs 구조 개선
  - 불필요한 이미지 제거 및 구조 정리
  - 지도 영역을 안내 박스로 대체하여 향후 `MapView` 컴포넌트로 교체 가능하게 함
- 일정 카드 UI `ScheduleCard.jsx`로 분리:
  - props로 일정 항목, 삭제/리뷰 핸들러 전달
  - 리뷰 버튼, 삭제 버튼, 시간 및 이동수단 표기 포함
- 추후 API 연동 또는 기능 확장에 유리한 구조로 전환

### 기대 효과
- 코드 가독성 및 유지보수성 향상
- 일정 데이터 연동, 리뷰 작성 등 기능 분리 개발 가능
- 지도 영역도 이후 쉽게 확장 가능

### 관련 이슈
- #34 내 일정 상세 페이지 구현

![image](https://github.com/user-attachments/assets/ca654a21-9a95-40c2-877b-820914c703d0)

