### PR TITLE
feat: 관리자 로그인 페이지 UI 구현 및 비동기 로그인 처리 (#60)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,16 +21,21 @@ import FinalRecommendationPage from "./pages/FinalRecommendationPage";
 import PlanDetailPage from "./pages/PlanDetailPage"; 
 
 
+import AdminLoginPage from "./pages/AdminLoginPage";
+
+
 import { TravelProvider } from "./contexts/TravelContext";
 import { AuthProvider } from "./contexts/AuthContext";
 
 import PrivateRoute from "./components/PrivateRoute";
 import Layout from "./components/Layout";
+import { AdminAuthProvider } from "./contexts/AdminAuthContext";
 
 function App() {
   return (
     <ChakraProvider>
       <AuthProvider>
+        <AdminAuthProvider>
         <TravelProvider>
           <Routes>
               <Route path="/" element={<HomePage />} />
@@ -109,14 +114,7 @@ function App() {
                 }
               />
 
-<Route
-                path="/mypage/profile"
-                element={
-                  <PrivateRoute>
-                    <ProfilePage />
-                  </PrivateRoute>
-                }
-              />
+<Route path="/mypage/profile" element={<PrivateRoute><ProfilePage /> </PrivateRoute>}/>
               <Route
                 path="/mypage/delete"
                 element={
@@ -135,9 +133,12 @@ function App() {
     </PrivateRoute>
   }
 />
+<Route path="/admin/login" element={<AdminLoginPage />} />
 
           </Routes>
+          
         </TravelProvider>
+        </AdminAuthProvider>
       </AuthProvider>
     </ChakraProvider>
   );

--- a/src/contexts/AdminAuthContext.jsx
+++ b/src/contexts/AdminAuthContext.jsx
@@ -1,0 +1,30 @@
+import React, { createContext, useState } from "react";
+
+export const AdminAuthContext = createContext();
+
+export const AdminAuthProvider = ({ children }) => {
+  const [isAdminLoggedIn, setIsAdminLoggedIn] = useState(false);
+
+  // 비동기 로그인 함수 (Promise로 감싸기)
+  const login = async (username, password) => {
+    return new Promise((resolve) => {
+      // 나중에 여기를 axios 요청으로 교체하면 됨
+      if (username === "admin" && password === "admin123") {
+        setIsAdminLoggedIn(true);
+        resolve({ success: true });
+      } else {
+        resolve({ success: false, message: "아이디 또는 비밀번호가 올바르지 않습니다." });
+      }
+    });
+  };
+
+  const logout = () => {
+    setIsAdminLoggedIn(false);
+  };
+
+  return (
+    <AdminAuthContext.Provider value={{ isAdminLoggedIn, login, logout }}>
+      {children}
+    </AdminAuthContext.Provider>
+  );
+};

--- a/src/pages/AdminLoginPage.jsx
+++ b/src/pages/AdminLoginPage.jsx
@@ -1,0 +1,92 @@
+import React, { useContext, useState } from "react";
+import {
+  Box,
+  Button,
+  Input,
+  Heading,
+  VStack,
+  FormControl,
+  FormLabel,
+  Alert,
+  AlertIcon,
+} from "@chakra-ui/react";
+import { AdminAuthContext } from "../contexts/AdminAuthContext";
+import { useNavigate } from "react-router-dom";
+
+const AdminLoginPage = () => {
+  const { login } = useContext(AdminAuthContext);
+  const navigate = useNavigate();
+
+  const [form, setForm] = useState({ username: "", password: "" });
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const { username, password } = form;
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const result = await login(username, password);
+      if (result.success) {
+        navigate("/admin");
+      } else {
+        setError(result.message);
+      }
+    } catch {
+      setError("알 수 없는 오류가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box maxW="md" mx="auto" mt={20} p={6} borderWidth={1} borderRadius="lg" boxShadow="lg">
+      <Heading size="md" mb={6} textAlign="center">관리자 로그인</Heading>
+
+      {error && (
+        <Alert status="error" mb={4}>
+          <AlertIcon />
+          {error}
+        </Alert>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        <VStack spacing={4}>
+          <FormControl>
+            <FormLabel>아이디</FormLabel>
+            <Input
+              name="username"
+              placeholder="관리자 아이디"
+              value={username}
+              onChange={handleChange}
+            />
+          </FormControl>
+
+          <FormControl>
+            <FormLabel>비밀번호</FormLabel>
+            <Input
+              name="password"
+              type="password"
+              placeholder="비밀번호"
+              value={password}
+              onChange={handleChange}
+            />
+          </FormControl>
+
+          <Button colorScheme="blue" type="submit" width="full" isLoading={loading}>
+            로그인
+          </Button>
+        </VStack>
+      </form>
+    </Box>
+  );
+};
+
+export default AdminLoginPage;


### PR DESCRIPTION
## 구현 내용

- 관리자 로그인 페이지 UI 구성
- 아이디, 비밀번호 입력 필드 추가
- 로그인 실패 시 오류 메시지 표시
- `AdminAuthContext`를 활용한 임시 로그인 로직 구현
- 향후 백엔드 연동을 고려해 `async/await` 기반으로 구조 작성

## 경로
- `/admin/login`

## 테스트 방법
1. `/admin/login` 접속
2. `아이디: admin / 비밀번호: admin123` 입력 시 로그인 성공
3. 그 외 입력 시 오류 메시지 출력

## 관련 이슈
Closes #60

![image](https://github.com/user-attachments/assets/b10d8923-2167-4020-8dc5-829d936a3327)
![image](https://github.com/user-attachments/assets/d8cfe739-59c5-4e3a-b65b-e7e6127c0ffb)

