### PR TITLE
feat: 관리자 대시보드 UI 및 로그아웃 버튼 구현 (#61)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,11 @@
         "@react-google-maps/api": "^2.20.6",
         "axios": "^1.8.4",
         "framer-motion": "^12.7.4",
+        "lucide-react": "^0.503.0",
         "react-datepicker": "^8.3.0",
         "react-icons": "^5.5.0",
-        "react-router-dom": "^7.5.1"
+        "react-router-dom": "^7.5.1",
+        "recharts": "^2.15.3"
       },
       "devDependencies": {
         "@vitejs/plugin-react-swc": "^3.9.0",
@@ -2812,6 +2814,69 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -3060,6 +3125,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -3087,6 +3273,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3101,6 +3293,16 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3223,11 +3425,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.4.3",
@@ -3494,6 +3711,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -3560,6 +3786,12 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
@@ -3576,6 +3808,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.503.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.503.0.tgz",
+      "integrity": "sha512-HGGkdlPWQ0vTF8jJ5TdIqhQXZi6uh3LnNgfZ8MHiuxFfX3RZeA79r2MW2tHAZKlAVfoNE8esm3p+O6VkIvpj6w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3980,6 +4221,21 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -4001,6 +4257,60 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redux": {
       "version": "5.0.1",
@@ -4242,6 +4552,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "@react-google-maps/api": "^2.20.6",
     "axios": "^1.8.4",
     "framer-motion": "^12.7.4",
+    "lucide-react": "^0.503.0",
     "react-datepicker": "^8.3.0",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^7.5.1"
+    "react-router-dom": "^7.5.1",
+    "recharts": "^2.15.3"
   },
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,9 @@ import PlanDetailPage from "./pages/PlanDetailPage";
 
 
 import AdminLoginPage from "./pages/AdminLoginPage";
+import AdminDashboard from "./components/admin/AdminDashboard";
+import AdminHome from "./components/admin/AdminHome";
+import AdminRoute from "./components/admin/AdminRoute";
 
 
 import { TravelProvider } from "./contexts/TravelContext";
@@ -134,6 +137,14 @@ function App() {
   }
 />
 <Route path="/admin/login" element={<AdminLoginPage />} />
+<Route
+            path="/admin"
+            element={<AdminRoute />}
+          >
+            <Route element={<AdminDashboard />}>
+            <Route index element={<AdminHome />} />
+            </Route>
+            </Route>
 
           </Routes>
           

--- a/src/components/admin/AdminDashboard.jsx
+++ b/src/components/admin/AdminDashboard.jsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import {
+  Box,
+  Flex,
+  Heading,
+  VStack,
+  Button,
+  Spacer,
+} from "@chakra-ui/react";
+import {
+  UserIcon,
+  MapPinIcon,
+  MessageSquareIcon,
+  BrainIcon,
+  SettingsIcon,
+  LogOutIcon,
+} from "lucide-react";
+import { useContext } from "react";
+import { AdminAuthContext } from "../../contexts/AdminAuthContext";
+
+const AdminDashboard = () => {
+  const navigate = useNavigate();
+  const { logout } = useContext(AdminAuthContext);
+
+  const handleLogout = () => {
+    logout();
+    navigate("/admin/login");
+  };
+
+  return (
+    <Flex minH="100vh" bg="gray.50">
+      {/* 좌측 사이드바 */}
+      <Box
+        w="240px"
+        bg="white"
+        p={6}
+        borderRight="1px solid #e2e8f0"
+        boxShadow="sm"
+        display="flex"
+        flexDirection="column"
+        justifyContent="space-between"
+      >
+        <Box>
+          {/* 로고 */}
+          <Box
+            mb={6}
+            textAlign="center"
+            cursor="pointer"
+            onClick={() => navigate("/admin")}
+          >
+            <img
+              src="/images/logo.png"
+              alt="관리자 로고"
+              style={{ width: "120px", margin: "0 auto" }}
+            />
+          </Box>
+
+          {/* 메뉴 */}
+          <VStack align="stretch" spacing={4}>
+            <Button
+              as={NavLink}
+              to="users"
+              variant="ghost"
+              colorScheme="teal"
+              justifyContent="start"
+              leftIcon={<UserIcon size={16} />}
+            >
+              회원 관리
+            </Button>
+            <Button
+              as={NavLink}
+              to="places"
+              variant="ghost"
+              colorScheme="teal"
+              justifyContent="start"
+              leftIcon={<MapPinIcon size={16} />}
+            >
+              여행지 관리
+            </Button>
+            <Button
+              as={NavLink}
+              to="reviews"
+              variant="ghost"
+              colorScheme="teal"
+              justifyContent="start"
+              leftIcon={<MessageSquareIcon size={16} />}
+            >
+              리뷰 관리
+            </Button>
+            <Button
+              as={NavLink}
+              to="ai"
+              variant="ghost"
+              colorScheme="teal"
+              justifyContent="start"
+              leftIcon={<BrainIcon size={16} />}
+            >
+              AI 관리
+            </Button>
+            <Button
+              as={NavLink}
+              to="account"
+              variant="ghost"
+              colorScheme="teal"
+              justifyContent="start"
+              leftIcon={<SettingsIcon size={16} />}
+            >
+              계정 설정
+            </Button>
+          </VStack>
+        </Box>
+
+        {/* 로그아웃 버튼 */}
+        <Box mt={8}>
+          <Button
+            onClick={handleLogout}
+            variant="ghost"
+            colorScheme="red"
+            width="100%"
+            justifyContent="start"
+            leftIcon={<LogOutIcon size={16} />}
+          >
+            로그아웃
+          </Button>
+        </Box>
+      </Box>
+
+      {/* 오른쪽 콘텐츠 */}
+      <Box flex="1" p={{ base: 6, md: 10 }}>
+        <Outlet />
+      </Box>
+    </Flex>
+  );
+};
+
+export default AdminDashboard;

--- a/src/components/admin/AdminHome.jsx
+++ b/src/components/admin/AdminHome.jsx
@@ -1,0 +1,221 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import {
+  Box, SimpleGrid, Card, CardHeader, CardBody, Heading, Text,
+  Badge, VStack, HStack, Flex
+} from "@chakra-ui/react";
+import {
+  UserIcon, MapPinIcon, MessageSquareIcon, CalendarIcon,
+  BarChart3Icon, PieChartIcon, BellIcon
+} from "lucide-react";
+import {
+  BarChart, Bar, PieChart, Pie, Cell,
+  Tooltip, ResponsiveContainer, XAxis, YAxis, Legend
+} from "recharts";
+import { useNavigate } from "react-router-dom";
+
+const COLORS = ["#3182CE", "#38B2AC", "#DD6B20", "#805AD5"];
+
+const AdminHome = () => {
+  const navigate = useNavigate();
+
+  // 상태 정의
+  const [stats, setStats] = useState([]);
+  const [barData, setBarData] = useState([]);
+  const [pieData, setPieData] = useState([]);
+  const [increaseData, setIncreaseData] = useState([]);
+  const [notices, setNotices] = useState([]);
+  const [qnaList, setQnaList] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  // 데이터 로딩
+  useEffect(() => {
+    const fetchDashboardData = async () => {
+      try {
+        // TODO: 실제 백엔드 API가 생기면 여기에 연결
+        // const res = await axios.get("/api/admin/dashboard");
+
+        // 임시 더미 데이터
+        setStats([
+          { icon: <UserIcon size={18} />, label: "총 회원 수", value: 120 },
+          { icon: <MapPinIcon size={18} />, label: "여행지 수", value: 32 },
+          { icon: <MessageSquareIcon size={18} />, label: "리뷰 수", value: 87 },
+          { icon: <CalendarIcon size={18} />, label: "일정 수", value: 45 },
+        ]);
+
+        setBarData([
+          { name: "회원", count: 120 },
+          { name: "여행지", count: 32 },
+          { name: "리뷰", count: 87 },
+          { name: "일정", count: 45 },
+        ]);
+
+        setPieData([
+          { name: "힐링", value: 40 },
+          { name: "먹방", value: 25 },
+          { name: "액티비티", value: 20 },
+          { name: "기타", value: 15 },
+        ]);
+
+        setIncreaseData([
+          { name: "회원", amount: 12 },
+          { name: "여행지", amount: 5 },
+          { name: "리뷰", amount: 18 },
+          { name: "일정", amount: 7 },
+        ]);
+
+        setNotices([
+          { id: 1, title: "[점검] 4월 5일 서버 점검 예정", date: "2025-03-29" },
+          { id: 2, title: "새로운 테마 여행지 추가", date: "2025-03-27" },
+        ]);
+
+        setQnaList([
+          { id: 1, question: "비밀번호를 잊어버렸어요.", date: "2025-03-25", answered: true },
+          { id: 2, question: "여행 일정은 몇 개까지 등록 가능한가요?", date: "2025-03-26", answered: false },
+        ]);
+      } catch (err) {
+        console.error("대시보드 데이터 불러오기 실패", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDashboardData();
+  }, []);
+
+  // 로딩 처리
+  if (loading) {
+    return <Text textAlign="center">대시보드 데이터를 불러오는 중입니다...</Text>;
+  }
+
+  return (
+    <Box p={6}>
+      <Heading size="lg" mb={6}>관리자 대시보드</Heading>
+
+      {/* 통계 카드 */}
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 4 }} spacing={4} mb={8}>
+        {stats.map((item, idx) => (
+          <Card key={idx} boxShadow="sm">
+            <CardHeader display="flex" alignItems="center" gap={2}>
+              {item.icon}
+              <Text fontWeight="bold">{item.label}</Text>
+            </CardHeader>
+            <CardBody>
+              <Heading size="md">{item.value}</Heading>
+              <Text fontSize="sm" color="gray.500">이번 달 기준</Text>
+            </CardBody>
+          </Card>
+        ))}
+      </SimpleGrid>
+
+      {/* 증감, 공지, QnA 카드 */}
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6} mb={8}>
+        {/* 이번 달 증가량 */}
+        <Card>
+          <CardHeader><Heading size="sm">이번 달 증가량</Heading></CardHeader>
+          <CardBody>
+            <VStack align="start" spacing={3}>
+              {increaseData.map((item, idx) => (
+                <HStack key={idx} justify="space-between" w="100%">
+                  <Text>{item.name}</Text>
+                  <Badge colorScheme="green">+{item.amount}</Badge>
+                </HStack>
+              ))}
+            </VStack>
+          </CardBody>
+        </Card>
+
+        {/* 공지사항 */}
+        <Card>
+          <CardHeader display="flex" justifyContent="space-between" alignItems="center">
+            <HStack
+              cursor="pointer"
+              onClick={() => navigate("/admin/notices")}
+              _hover={{ textDecoration: "underline", color: "teal.600" }}
+            >
+              <BellIcon size={18} />
+              <Heading size="sm">공지사항</Heading>
+            </HStack>
+            <Text fontSize="xs" color="gray.400">(더보기)</Text>
+          </CardHeader>
+          <CardBody>
+            <VStack align="start" spacing={3}>
+              {notices.map((notice) => (
+                <Box
+                  key={notice.id}
+                  cursor="pointer"
+                  onClick={() => navigate(`/admin/notices/${notice.id}`)}
+                  _hover={{ bg: "gray.50" }}
+                  p={2}
+                  borderRadius="md"
+                >
+                  <Text fontSize="sm" fontWeight="medium">{notice.title}</Text>
+                  <Text fontSize="xs" color="gray.500">{notice.date}</Text>
+                </Box>
+              ))}
+            </VStack>
+          </CardBody>
+        </Card>
+
+        {/* QnA */}
+        <Card>
+          <CardHeader>
+            <Heading size="sm">Q&A 문의</Heading>
+          </CardHeader>
+          <CardBody>
+            <Text fontSize="sm" mb={2}>총 문의: {qnaList.length}건</Text>
+            <Text fontSize="sm" color="red.500">
+              미답변: {qnaList.filter((q) => !q.answered).length}건
+            </Text>
+          </CardBody>
+        </Card>
+      </SimpleGrid>
+
+      {/* 하단 차트 */}
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={6}>
+        <Card>
+          <CardHeader><BarChart3Icon size={18} /><Heading size="sm" ml={2}>데이터 요약</Heading></CardHeader>
+          <CardBody>
+            <Box height="300px">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={barData}>
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Bar dataKey="count" fill="#3182CE" />
+                </BarChart>
+              </ResponsiveContainer>
+            </Box>
+          </CardBody>
+        </Card>
+
+        <Card>
+          <CardHeader><PieChartIcon size={18} /><Heading size="sm" ml={2}>선호 여행 무드</Heading></CardHeader>
+          <CardBody>
+            <Box height="300px">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={pieData}
+                    dataKey="value"
+                    nameKey="name"
+                    outerRadius={80}
+                    label
+                  >
+                    {pieData.map((entry, index) => (
+                      <Cell key={`cell-${index}`} fill={COLORS[index]} />
+                    ))}
+                  </Pie>
+                  <Tooltip />
+                </PieChart>
+              </ResponsiveContainer>
+            </Box>
+          </CardBody>
+        </Card>
+      </SimpleGrid>
+    </Box>
+  );
+};
+
+export default AdminHome;

--- a/src/components/admin/AdminRoute.jsx
+++ b/src/components/admin/AdminRoute.jsx
@@ -1,0 +1,15 @@
+import React, { useContext } from "react";
+import { Navigate, Outlet } from "react-router-dom";
+import { AdminAuthContext } from "../../contexts/AdminAuthContext";
+
+const AdminRoute = ( ) => {
+  const { isAdminLoggedIn } = useContext(AdminAuthContext);
+
+  if (!isAdminLoggedIn) {
+    return <Navigate to="/admin/login" replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default AdminRoute;


### PR DESCRIPTION
## 구현 내용

- 관리자 대시보드 UI 전체 구성
- 통계 카드, 차트, 공지사항, Q&A 등 관리자 홈 정보 시각화
- `AdminHome.jsx`에서 더미 데이터를 `useEffect`로 관리 (백엔드 연동 준비됨)
- 사이드바 하단에 로그아웃 버튼 추가
  - `AdminAuthContext.logout()` 사용
  - 로그아웃 시 `/admin/login`으로 리디렉션

## 접근 경로
- `/admin`

## 테스트 방법
1. `/admin` 접속 시 관리자 홈 대시보드 정상 렌더링 확인
2. 사이드바 하단에서 로그아웃 버튼 클릭 → 로그인 페이지로 이동 확인

## 관련 이슈
Closes #61

![image](https://github.com/user-attachments/assets/a623bbba-8fb9-4655-ac8f-f94603f9fadb)
![image](https://github.com/user-attachments/assets/13c7b55f-f3ef-4a88-aac0-3c3d9f18b1d8)
