### PR TITLE
feat: 관리자 Q&A 관리 UI 및 대시보드 통계 카드 구현 (#66)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,9 @@ import AdminNoticeCreate from "./components/admin/AdminNoticeCreate";
 import AdminNoticeEdit from "./components/admin/AdminNoticeEdit";
 import AdminNoticeDetail from "./components/admin/AdminNoticeDetail";
 
+import AdminQnaList from "./components/admin/AdminQnaList";
+import AdminQnaDetail from "./components/admin/AdminQnaDetail";
+
 
 import { TravelProvider } from "./contexts/TravelContext";
 import { AuthProvider } from "./contexts/AuthContext";
@@ -152,6 +155,10 @@ function App() {
             <Route path="notices/new" element={<AdminNoticeCreate />} />
             <Route path="notices/:id/edit" element={<AdminNoticeEdit />} />
             <Route path="notices/:id" element={<AdminNoticeDetail />} />
+
+            <Route path="qna" element={<AdminQnaList />} />
+            <Route path="qna/:id" element={<AdminQnaDetail />} />
+            
             </Route>
             </Route>
 

--- a/src/components/admin/AdminHome.jsx
+++ b/src/components/admin/AdminHome.jsx
@@ -13,6 +13,7 @@ import {
   Tooltip, ResponsiveContainer, XAxis, YAxis, Legend
 } from "recharts";
 import { useNavigate } from "react-router-dom";
+import { dummyQnaList } from "./dummyQna"; // 실제 위치에 맞게 경로 조정
 
 const COLORS = ["#3182CE", "#38B2AC", "#DD6B20", "#805AD5"];
 
@@ -159,16 +160,53 @@ const AdminHome = () => {
 
         {/* QnA */}
         <Card>
-          <CardHeader>
-            <Heading size="sm">Q&A 문의</Heading>
-          </CardHeader>
-          <CardBody>
-            <Text fontSize="sm" mb={2}>총 문의: {qnaList.length}건</Text>
-            <Text fontSize="sm" color="red.500">
-              미답변: {qnaList.filter((q) => !q.answered).length}건
-            </Text>
-          </CardBody>
-        </Card>
+  <CardHeader
+    display="flex"
+    alignItems="center"
+    justifyContent="space-between"
+  >
+    <HStack
+      cursor="pointer"
+      onClick={() => navigate("/admin/qna")}
+      _hover={{ textDecoration: "underline", color: "teal.600" }}
+    >
+      <MessageSquareIcon size={18} />
+      <Heading size="sm">Q&A 문의</Heading>
+    </HStack>
+    <Text fontSize="xs" color="gray.400">(전체 보기)</Text>
+  </CardHeader>
+
+  <CardBody>
+    <VStack align="start" spacing={3}>
+      <HStack fontSize="sm">
+        <Text>총 문의:</Text>
+        <Text fontWeight="bold">{dummyQnaList.length}건</Text>
+        <Text ml={4}>미답변:</Text>
+        <Text fontWeight="bold" color="red.500">
+          {dummyQnaList.filter((q) => !q.answered).length}건
+        </Text>
+      </HStack>
+
+      {/* 최근 문의 하나 표시 */}
+      {dummyQnaList
+        .filter((q) => !q.answered)
+        .slice(0, 1)
+        .map((qna) => (
+          <Box
+            key={qna.id}
+            p={2}
+            cursor="pointer"
+            borderRadius="md"
+            _hover={{ bg: "gray.50" }}
+            onClick={() => navigate(`/admin/qna/${qna.id}`)}
+          >
+            <Text fontSize="sm" fontWeight="medium">{qna.question}</Text>
+            <Text fontSize="xs" color="gray.500">{qna.date}</Text>
+          </Box>
+        ))}
+    </VStack>
+  </CardBody>
+</Card>
       </SimpleGrid>
 
       {/* 하단 차트 */}

--- a/src/components/admin/AdminQnaDetail.jsx
+++ b/src/components/admin/AdminQnaDetail.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  Box, Heading, Text, Textarea, Button,
+  VStack, HStack, Badge
+} from "@chakra-ui/react";
+import { dummyQnaList } from "./dummyQna";
+
+const AdminQnaDetail = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const qna = dummyQnaList.find((q) => q.id === parseInt(id));
+
+  const [answer, setAnswer] = useState(qna?.answer || "");
+
+  if (!qna) {
+    return <Text color="red.500">Q&A를 찾을 수 없습니다.</Text>;
+  }
+
+  const handleSaveAnswer = () => {
+    console.log("답변 저장:", answer);
+    qna.answer = answer;
+    qna.answered = true;
+    navigate("/admin/qna");
+  };
+
+  return (
+    <Box p={6}>
+      <Heading size="lg" mb={6}>Q&A 상세</Heading>
+
+      <Box mb={6}>
+        <Heading size="md" mb={2}>{qna.question}</Heading>
+        <Text fontSize="sm" color="gray.500">{qna.date}</Text>
+        <Text fontSize="sm" color="gray.600" mt={1}>작성자: {qna.user}</Text>
+        <Text mt={4}>{qna.content}</Text>
+      </Box>
+
+      <VStack align="stretch" spacing={4}>
+        <HStack>
+          <Text>답변 상태:</Text>
+          <Badge colorScheme={qna.answered ? "green" : "red"}>
+            {qna.answered ? "답변 완료" : "미답변"}
+          </Badge>
+        </HStack>
+
+        <Text fontWeight="bold">답변:</Text>
+        <Textarea
+          value={answer}
+          onChange={(e) => setAnswer(e.target.value)}
+          placeholder="답변을 작성하세요."
+          size="md"
+        />
+        <Button
+          colorScheme="teal"
+          onClick={handleSaveAnswer}
+          disabled={!answer.trim()}
+        >
+          저장
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default AdminQnaDetail;

--- a/src/components/admin/AdminQnaList.jsx
+++ b/src/components/admin/AdminQnaList.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box, Heading, Text, VStack, Input, Button, HStack, Badge
+} from "@chakra-ui/react";
+import { dummyQnaList } from "./dummyQna";
+
+const AdminQnaList = () => {
+  const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState("");
+  const [filter, setFilter] = useState("all");
+
+  const filteredQnaList = dummyQnaList.filter((qna) => {
+    const matchesSearch =
+      qna.question.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      qna.content.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesFilter =
+      filter === "all" || (filter === "answered" && qna.answered) || (filter === "unanswered" && !qna.answered);
+    return matchesSearch && matchesFilter;
+  });
+
+  return (
+    <Box p={6}>
+      <Heading size="md" mb={4}>Q&A 관리</Heading>
+
+      <Input
+        placeholder="검색..."
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        mb={4}
+      />
+
+      <HStack spacing={4} mb={6}>
+        <Button onClick={() => setFilter("all")}>전체</Button>
+        <Button onClick={() => setFilter("answered")}>답변 완료</Button>
+        <Button onClick={() => setFilter("unanswered")}>미답변</Button>
+      </HStack>
+
+      <VStack align="stretch" spacing={4}>
+        {filteredQnaList.map((qna) => (
+          <Box
+            key={qna.id}
+            p={4}
+            bg="white"
+            borderRadius="md"
+            boxShadow="sm"
+          >
+            <HStack justify="space-between">
+              <Box>
+                <Text fontWeight="bold">{qna.question}</Text>
+                <Text fontSize="sm" color="gray.500">{qna.date}</Text>
+                <Text fontSize="sm" color="gray.600">작성자: {qna.user}</Text>
+              </Box>
+              <HStack>
+                <Badge colorScheme={qna.answered ? "green" : "red"}>
+                  {qna.answered ? "답변 완료" : "미답변"}
+                </Badge>
+                <Button
+                  size="sm"
+                  colorScheme="teal"
+                  onClick={() => navigate(`/admin/qna/${qna.id}`)}
+                >
+                  보기
+                </Button>
+              </HStack>
+            </HStack>
+          </Box>
+        ))}
+      </VStack>
+    </Box>
+  );
+};
+
+export default AdminQnaList;

--- a/src/components/admin/dummyQna.js
+++ b/src/components/admin/dummyQna.js
@@ -1,0 +1,20 @@
+export const dummyQnaList = [
+    {
+      id: 1,
+      question: "비밀번호를 잊어버렸어요.",
+      content: "로그인이 안됩니다. 어떻게 해야 하나요?",
+      date: "2025-03-25",
+      answer: "비밀번호 재설정 링크를 보내드리겠습니다.",
+      answered: true,
+      user: "홍길동",
+    },
+    {
+      id: 2,
+      question: "여행 일정은 몇 개까지 등록 가능한가요?",
+      content: "최대 등록 가능한 일정 개수가 궁금합니다.",
+      date: "2025-03-26",
+      answer: "",
+      answered: false,
+      user: "김철수",
+    },
+  ];


### PR DESCRIPTION
## 구현 내용

- 관리자 Q&A 관리 전체 UI 구현
  - Q&A 목록 페이지: 필터(전체/답변완료/미답변), 검색 기능
  - 상세 보기 페이지: 질문 정보, 답변 작성, 저장 기능
- 답변 작성 시 `console.log`로 저장 확인 가능
- 유효성 검사 및 빈값 저장 방지 처리
- `dummyQnaList` 파일로 더미 데이터 통합 관리
- 관리자 대시보드에서 Q&A 통계 카드 구현
  - 총 문의 수 / 미답변 수 / 최근 미답변 질문 표시
  - Q&A 상세 페이지로 이동 가능

## 경로
- `/admin/qna` : Q&A 목록
- `/admin/qna/:id` : Q&A 상세 및 답변
- `/admin` : Q&A 통계 카드 추가

## 테스트 방법
1. `/admin/qna` 접속 시 전체 목록/검색/필터 동작 확인
2. 각 항목 '보기' 클릭 → 상세 페이지로 이동
3. 답변 작성 후 저장 클릭 → 콘솔 출력 확인 + 목록 이동
4. `/admin`에서 Q&A 카드 확인 (총/미답변 수, 최근 문의 표시)

## 관련 이슈
Closes #63

![image](https://github.com/user-attachments/assets/ded26ea2-2d8e-4aeb-9af1-6d6ec6cdc497)
![image](https://github.com/user-attachments/assets/a20908dc-bd48-45e6-bfe8-fc0500b47ccd)
![image](https://github.com/user-attachments/assets/ee71c10a-ebc8-42a5-9a68-c9a092e5ef6e)


