### PR TITLE
feat: [Admin] 계정 설정 기능 구현 #80

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,6 +46,8 @@ import AdminSchedules from "./components/admin/AdminSchedules";
 
 import AdminAIPage from "./components/admin/AdminAIPage";
 
+import AdminAccountSetting from "./components/admin/AdminAccountSetting";
+
 import { TravelProvider } from "./contexts/TravelContext";
 import { AuthProvider } from "./contexts/AuthContext";
 
@@ -181,6 +183,8 @@ function App() {
             <Route path="schedules" element={<AdminSchedules />} />
 
             <Route path="ai" element={<AdminAIPage />} />
+
+            <Route path="account" element={<AdminAccountSetting />} />
 
             </Route>
             </Route>

--- a/src/components/admin/AdminAccountSetting.jsx
+++ b/src/components/admin/AdminAccountSetting.jsx
@@ -1,0 +1,149 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Heading,
+  FormControl,
+  FormLabel,
+  Input,
+  Button,
+  VStack,
+  useToast,
+  Switch,
+  HStack,
+} from "@chakra-ui/react";
+
+const AdminAccountSetting = () => {
+  const [adminInfo] = useState({
+    name: "관리자",
+    email: "admin@example.com",
+    lastLogin: "2025-03-30 13:42",
+  });
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [newEmail, setNewEmail] = useState("");
+  const [is2FAEnabled, setIs2FAEnabled] = useState(false);
+
+  const toast = useToast();
+
+  const handlePasswordChange = () => {
+    if (!currentPassword || !newPassword || !confirmPassword) {
+      toast({ title: "모든 항목을 입력해주세요.", status: "warning", duration: 2000, isClosable: true });
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      toast({ title: "새 비밀번호가 일치하지 않습니다.", status: "error", duration: 2000, isClosable: true });
+      return;
+    }
+    toast({ title: "비밀번호가 변경되었습니다.", status: "success", duration: 2000, isClosable: true });
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+  };
+
+  const handleEmailChange = () => {
+    if (!newEmail) {
+      toast({ title: "새 이메일을 입력해주세요.", status: "warning", duration: 2000, isClosable: true });
+      return;
+    }
+    toast({ title: "이메일이 변경되었습니다.", status: "success", duration: 2000, isClosable: true });
+    setNewEmail("");
+  };
+
+  const toggle2FA = () => {
+    setIs2FAEnabled((prev) => !prev);
+    toast({
+      title: is2FAEnabled ? "2단계 인증이 비활성화되었습니다." : "2단계 인증이 활성화되었습니다.",
+      status: "info",
+      duration: 2000,
+      isClosable: true,
+    });
+  };
+
+  return (
+    <Box
+      maxW="600px"
+      mx="auto"
+      p={8}
+      bg="white"
+      borderRadius="md"
+      boxShadow="sm"
+    >
+      <Heading size="md" mb={6}>
+        계정 설정
+      </Heading>
+
+      <VStack spacing={4} align="stretch">
+        <FormControl isReadOnly>
+          <FormLabel>이름</FormLabel>
+          <Input value={adminInfo.name} isReadOnly />
+        </FormControl>
+
+        <FormControl isReadOnly>
+          <FormLabel>현재 이메일</FormLabel>
+          <Input value={adminInfo.email} isReadOnly />
+        </FormControl>
+
+        <FormControl>
+          <FormLabel>새 이메일 주소</FormLabel>
+          <Input
+            value={newEmail}
+            onChange={(e) => setNewEmail(e.target.value)}
+            placeholder="새 이메일 입력"
+          />
+        </FormControl>
+        <Button colorScheme="teal" onClick={handleEmailChange}>
+          이메일 변경
+        </Button>
+
+        <FormControl isReadOnly>
+          <FormLabel>마지막 로그인</FormLabel>
+          <Input value={adminInfo.lastLogin} isReadOnly />
+        </FormControl>
+
+        <HStack mt={4} align="center">
+          <FormLabel mb="0">2단계 인증 활성화</FormLabel>
+          <Switch isChecked={is2FAEnabled} onChange={toggle2FA} />
+        </HStack>
+
+        <Heading size="sm" mt={6}>
+          비밀번호 변경
+        </Heading>
+
+        <FormControl>
+          <FormLabel>현재 비밀번호</FormLabel>
+          <Input
+            type="password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+          />
+        </FormControl>
+
+        <FormControl>
+          <FormLabel>새 비밀번호</FormLabel>
+          <Input
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+          />
+        </FormControl>
+
+        <FormControl>
+          <FormLabel>새 비밀번호 확인</FormLabel>
+          <Input
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+          />
+        </FormControl>
+
+        <Button colorScheme="teal" onClick={handlePasswordChange}>
+          비밀번호 변경
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default AdminAccountSetting;


### PR DESCRIPTION
## 구현 내용

- 관리자 계정 설정 UI 및 기능 구현
  - 현재 관리자 정보 확인 (이름, 이메일, 마지막 로그인 시간)
  - 새 이메일 입력 및 변경 기능
  - 비밀번호 변경 (현재/새 비밀번호 확인 포함)
  - 2단계 인증 스위치 (UI 전용 피드백)
  - 입력 오류 및 성공 메시지 토스트 처리

---

## 테스트

- 입력 필드 누락 시 경고 메시지 표시 
- 새 비밀번호 불일치 시 오류 메시지 표시 
- 이메일, 비밀번호 변경 시 성공 메시지 표시  
- 2단계 인증 토글 시 상태에 맞는 안내 메시지 출력 

---

## 관련 이슈  
- close #80

![image](https://github.com/user-attachments/assets/33709c8f-1cbc-4650-b0e9-c4daa290570e)
![image](https://github.com/user-attachments/assets/7aadeb90-0b64-4d28-924a-bbcd0a633b21)
