### PR TITLE
feat: 홈화면 가이드 추가 및 돋보기 버튼 제거

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -99,12 +99,6 @@ function HomePage() {
         </Button>
         <HStack mt={4} justify="center">
           <DateFilterDropdown />
-          <IconButton
-            icon={<SearchIcon />}
-            colorScheme="blue"
-            aria-label="검색"
-            onClick={handleSearch}
-          />
         </HStack>
       </Box>
 
@@ -143,6 +137,39 @@ function HomePage() {
           )}
         </GridItem>
       </Grid>
+      <Box bg="gray.50" py={10} px={4} mt={20}>
+      <Heading size="md" textAlign="center" mb={8}>
+        ✨ 느낌표 사용 가이드
+      </Heading>
+
+      <Grid templateColumns={{ base: "1fr", md: "repeat(4, 1fr)" }} gap={6} textAlign="center">
+        <Box>
+          <Text fontSize="3xl">📅</Text>
+          <Text mt={2} fontWeight="semibold">1단계</Text>
+          <Text fontSize="sm">여행 날짜를 선택하세요</Text>
+        </Box>
+
+        <Box>
+          <Text fontSize="3xl">📝</Text>
+          <Text mt={2} fontWeight="semibold">2단계</Text>
+          <Text fontSize="sm">여행 설문에 응답하세요</Text>
+        </Box>
+
+        <Box>
+          <Text fontSize="3xl">📍</Text>
+          <Text mt={2} fontWeight="semibold">3단계</Text>
+          <Text fontSize="sm">AI 추천 여행지를 확인하세요</Text>
+        </Box>
+
+        <Box>
+          <Text fontSize="3xl">🧳</Text>
+          <Text mt={2} fontWeight="semibold">4단계</Text>
+          <Text fontSize="sm">일정을 저장하고 공유해보세요!</Text>
+        </Box>
+      </Grid>
+    </Box>
+
+      
     </Box>
   );
 }


### PR DESCRIPTION
## 주요 변경 사항

1. **돋보기 버튼 삭제**
   - 검색 기능이 '시작하기' 버튼과 동일하게 작동하고 있어 중복 제거
   - UX 혼란 방지를 위해 UI 정리

2. **느낌표 사용 가이드 섹션 추가**
   - 사용자 이해를 돕기 위한 4단계 안내 구성
   - 위치: 최근 일정/핫한 여행지 아래
   - 각 단계에 아이콘 및 설명 포함 (여행 날짜 선택 → 설문 응답 → AI 추천 → 일정 저장/공유)

## 목적
- 홈페이지 하단 공백을 자연스럽게 채우기 위해 시각적 요소 추가
- 처음 방문하는 사용자에게 사용 흐름을 친절하게 안내
- UI 간결화 (중복 기능 제거)

## 변경된 UI 미리보기
![image](https://github.com/user-attachments/assets/20c76be6-f63d-43fc-a334-52d673f454cb)

## 기타
- 기능 로직은 그대로 유지
- 컴포넌트 분리는 하지 않음 (홈 전용 섹션이므로)

